### PR TITLE
Fix a bug where editext underline might crash the app when trying to set a background drawable

### DIFF
--- a/android/app/src/main/res/values/styles.xml
+++ b/android/app/src/main/res/values/styles.xml
@@ -4,6 +4,12 @@
     <style name="AppTheme" parent="Theme.AppCompat.Light.NoActionBar">
         <!-- Customize your theme here. -->
         <item name="android:windowBackground">@drawable/splash_screen</item>
+        <item name="android:editTextStyle">@style/MendixEditText</item>
+    </style>
+
+
+    <style name="MendixEditText" parent="Widget.AppCompat.EditText">
+        <item name="android:background">@android:color/transparent</item>
     </style>
 
 </resources>


### PR DESCRIPTION
This fix was introduced to the Make it Native more than a year ago and for a reason. Therefore, it also has to be part of the Native Template. As a side-effect it solves the problem with the different height of text inputs between the Native Template and Make it Native.