### PR TITLE
Exclude node_modules only at the toplevel because ios bundle also contains node_modules, which should not be excluded

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,7 +38,8 @@ ios/Pods/
 
 # node.js
 #
-node_modules/
+# Use / before node_modules because iOS assets folder has a node_modules folder that should not be excluded.
+/node_modules/
 npm-debug.log
 yarn-error.log
 


### PR DESCRIPTION
This is important when building locally using a private repository.