### PR TITLE
Enable legacy storage to support Android 10/11

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -28,7 +28,8 @@
       android:roundIcon="@mipmap/ic_launcher_round"
       android:allowBackup="false"
       android:largeHeap="true"
-      android:theme="@style/AppTheme">
+      android:theme="@style/AppTheme"
+      android:requestLegacyExternalStorage="true">
       <activity
         android:name="com.mendix.nativetemplate.MainActivity"
         android:label="@string/app_name"


### PR DESCRIPTION
Out of google's docs: 
`If your app targets Android 10 (API level 29), opt-out of scoped storage and continue using the approach for Android 9 and lower to perform this operation.`