### PR TITLE
[NALM-1250] Default to adjustPan for soft keyboard

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -35,7 +35,7 @@
         android:label="@string/app_name"
         android:screenOrientation="portrait"
         android:configChanges="keyboard|keyboardHidden|orientation|screenSize|uiMode"
-        android:windowSoftInputMode="adjustResize">
+        android:windowSoftInputMode="adjustPan">
         <intent-filter>
             <action android:name="android.intent.action.MAIN" />
             <category android:name="android.intent.category.LAUNCHER" />


### PR DESCRIPTION
Adjust resize can mess with the scrollview's children blur/focus  behaviour. This should alleviate the issue as it would default in panning the view instead of resizing the viewport.