### PR TITLE
Make App Center scripts to fail early

### DIFF
--- a/appcenter-post-clone.sh
+++ b/appcenter-post-clone.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+set -e
 
 # Untar bundle resources
 if [ -f "./android/res.tar.gz" ]; then 

--- a/appcenter-pre-build.sh
+++ b/appcenter-pre-build.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+set -e
 
 if [[ $SUPPORTS_MOBILE_TOOLKIT == True ]]; then
     echo "Configuring template with mobile toolkit"


### PR DESCRIPTION
This makes sure when either of the scripts fail, it causes App Center build to fail early