### PR TITLE
[MOO-304] Crashlytics capability support

### DIFF
--- a/capabilities-setup-config.json
+++ b/capabilities-setup-config.json
@@ -54,6 +54,44 @@
             }
         }
     },
+    "crashlytics": {
+        "android": {
+            "gradle": {
+                "classpaths": [
+                    "com.google.firebase:firebase-crashlytics-gradle:2.0.0"
+                ],
+                "plugins": [
+                    "com.google.firebase.crashlytics"
+                ]
+            },
+            "externalDependencies": [
+                "com.google.firebase:firebase-bom:26.0.0",
+                "com.google.firebase:firebase-crashlytics:17.0.0",
+                "com.google.firebase:firebase-analytics:17.4.0"
+            ]
+        },
+        "ios": {
+            "pods": {
+                "FirebaseCrashlytics": {
+                    "version": "~> 4.0.0-beta.5"
+                },
+                "FirebaseAnalytics": {
+                    "version": "~> 6.3.1"
+                }
+            },
+            "buildPhases": [
+                {
+                    "name": "[RNFB] Crashlytics Configuration",
+                    "path": "./ios/crashlytics-config.sh",
+                    "execution_position": "after_compile",
+                    "input_files": [
+                        "${DWARF_DSYM_FOLDER_PATH}/${DWARF_DSYM_FILE_NAME}/Contents/Resources/DWARF/${TARGET_NAME}",
+                        "$(SRCROOT)/$(BUILT_PRODUCTS_DIR)/$(INFOPLIST_PATH)"
+                    ]
+                }
+            ]
+        }
+    },
     "firebaseAndroid": {
         "android": {
             "gradle": {

--- a/capabilities-setup-config.json
+++ b/capabilities-setup-config.json
@@ -26,25 +26,15 @@
                     "new RNFirebaseMessagingPackage()",
                     "new RNFirebaseNotificationsPackage()"
                 ]
-            },
-            "gradle": {
-                "classpaths": [
-                    "com.google.gms:google-services:4.2.0"
-                ],
-                "plugins": [
-                    "com.google.gms.google-services"
-                ]
             }
         },
         "ios": {
             "AppDelegate": {
                 "imports": [
-                    "#import <Firebase.h>",
                     "#import \"RNFirebase/RNFirebaseNotifications.h\"",
                     "#import \"RNFirebase/RNFirebaseMessaging.h\""
                 ],
                 "didFinishLaunchingWithOptions": [
-                    "[FIRApp configure];",
                     "[RNFirebaseNotifications configure];"
                 ],
                 "didReceiveLocalNotification": [
@@ -58,13 +48,39 @@
                 ]
             },
             "pods": {
+                "Firebase/Messaging": {
+                    "version": "~> 6.19.0"
+                }
+            }
+        }
+    },
+    "firebaseAndroid": {
+        "android": {
+            "gradle": {
+                "classpaths": [
+                    "com.google.gms:google-services:4.2.0"
+                ],
+                "plugins": [
+                    "com.google.gms.google-services"
+                ]
+            }
+        }
+    },
+    "firebaseIos": {
+        "ios": {
+            "AppDelegate": {
+                "imports": [
+                    "#import <Firebase.h>"
+                ],
+                "didFinishLaunchingWithOptions": [
+                    "[FIRApp configure];"
+                ]
+            },
+            "pods": {
                 "RNFirebase": {
                     "path": "react-native-firebase/ios"
                 },
                 "Firebase/Core": {
-                    "version": "~> 6.19.0"
-                },
-                "Firebase/Messaging": {
                     "version": "~> 6.19.0"
                 },
                 "GoogleUtilities": {

--- a/capabilities-setup-config.json
+++ b/capabilities-setup-config.json
@@ -14,7 +14,7 @@
     "pushNotifications": {
         "android": {
             "externalDependencies": [
-                "com.google.firebase:firebase-messaging:20.1.2",
+                "com.google.firebase:firebase-messaging:20.1.6",
                 "me.leolin:ShortcutBadger:1.1.22@aar"
             ],
             "packageListEntries": {
@@ -49,7 +49,7 @@
             },
             "pods": {
                 "Firebase/Messaging": {
-                    "version": "~> 6.19.0"
+                    "version": "~> 6"
                 }
             }
         }
@@ -65,18 +65,17 @@
                 ]
             },
             "externalDependencies": [
-                "com.google.firebase:firebase-bom:26.0.0",
-                "com.google.firebase:firebase-crashlytics:17.0.0",
+                "com.google.firebase:firebase-crashlytics:17.4.0",
                 "com.google.firebase:firebase-analytics:17.4.0"
             ]
         },
         "ios": {
             "pods": {
-                "FirebaseCrashlytics": {
-                    "version": "~> 4.0.0-beta.5"
+                "Firebase/Crashlytics": {
+                    "version": "~> 6"
                 },
-                "FirebaseAnalytics": {
-                    "version": "~> 6.3.1"
+                "Firebase/Core": {
+                    "version": "~> 6"
                 }
             },
             "buildPhases": [

--- a/capabilities.android.json
+++ b/capabilities.android.json
@@ -1,6 +1,9 @@
 {
     "deepLink": false,
     "pushNotifications": false,
+    "crashlytics": false,
+    "firebaseAndroid": false,
+    "firebaseIos": false,
     "bluetooth": true,
     "appCenterOTA": false,
     "maps": true,

--- a/capabilities.ios.json
+++ b/capabilities.ios.json
@@ -1,6 +1,9 @@
 {
     "deepLink": false,
     "pushNotifications": false,
+    "crashlytics": false,
+    "firebaseAndroid": false,
+    "firebaseIos": false,
     "bluetooth": true,
     "appCenterOTA": false,
     "maps": true,

--- a/ios/crashlytics-config.sh
+++ b/ios/crashlytics-config.sh
@@ -1,0 +1,3 @@
+set -e
+
+"${PODS_ROOT}/FirebaseCrashlytics/run"

--- a/patches/react-native-firebase+5.6.0.patch
+++ b/patches/react-native-firebase+5.6.0.patch
@@ -1,3 +1,18 @@
+diff --git a/node_modules/react-native-firebase/android/build.gradle b/node_modules/react-native-firebase/android/build.gradle
+index 3e74895..e38df36 100644
+--- a/node_modules/react-native-firebase/android/build.gradle
++++ b/node_modules/react-native-firebase/android/build.gradle
+@@ -183,10 +183,6 @@ dependencies {
+   compileOnly "com.google.firebase:firebase-firestore:19.0.2"
+   // Cloud Messaging / FCM
+   compileOnly "com.google.firebase:firebase-messaging:18.0.0"
+-  // Crashlytics
+-  compileOnly('com.crashlytics.sdk.android:crashlytics:2.10.1@aar') {
+-    transitive = true
+-  }
+   /* --------------------------------
+    *  OPTIONAL SUPPORT LIBS
+    * -------------------------------- */
 diff --git a/node_modules/react-native-firebase/android/src/main/java/io/invertase/firebase/RNFirebaseModule.java b/node_modules/react-native-firebase/android/src/main/java/io/invertase/firebase/RNFirebaseModule.java
 index 24f472e..085f926 100644
 --- a/node_modules/react-native-firebase/android/src/main/java/io/invertase/firebase/RNFirebaseModule.java
@@ -54,6 +69,176 @@ index 24f472e..085f926 100644
      }
  
      constants.put("apps", appMapsList);
+diff --git a/node_modules/react-native-firebase/android/src/main/java/io/invertase/firebase/fabric/crashlytics/RNFirebaseCrashlytics.java b/node_modules/react-native-firebase/android/src/main/java/io/invertase/firebase/fabric/crashlytics/RNFirebaseCrashlytics.java
+deleted file mode 100644
+index 7e2ae4c..0000000
+--- a/node_modules/react-native-firebase/android/src/main/java/io/invertase/firebase/fabric/crashlytics/RNFirebaseCrashlytics.java
++++ /dev/null
+@@ -1,120 +0,0 @@
+-package io.invertase.firebase.fabric.crashlytics;
+-
+-import android.util.Log;
+-
+-import com.crashlytics.android.Crashlytics;
+-import com.facebook.react.bridge.ReactApplicationContext;
+-import com.facebook.react.bridge.ReactContextBaseJavaModule;
+-import com.facebook.react.bridge.ReactMethod;
+-import com.facebook.react.bridge.ReadableArray;
+-import com.facebook.react.bridge.ReadableMap;
+-
+-import java.util.ArrayList;
+-
+-import io.fabric.sdk.android.Fabric;
+-
+-public class RNFirebaseCrashlytics extends ReactContextBaseJavaModule {
+-
+-  private static final String TAG = "RNFirebaseCrashlytics";
+-
+-  public RNFirebaseCrashlytics(ReactApplicationContext reactContext) {
+-    super(reactContext);
+-    Log.d(TAG, "New instance");
+-  }
+-
+-  @Override
+-  public String getName() {
+-    return TAG;
+-  }
+-
+-  @ReactMethod
+-  public void crash() {
+-    Crashlytics
+-      .getInstance()
+-      .crash();
+-  }
+-
+-  @ReactMethod
+-  public void log(final String message) {
+-    Crashlytics.log(message);
+-  }
+-
+-  @ReactMethod
+-  public void recordError(final int code, final String domain) {
+-    Crashlytics.logException(new Exception(code + ": " + domain));
+-  }
+-
+-  @ReactMethod
+-  public void recordCustomError(String name, String reason, ReadableArray frameArray) {
+-      ArrayList<StackTraceElement> stackList = new ArrayList<>(0);
+-      for (int i = 0; i < frameArray.size(); i++) {
+-        ReadableMap map = frameArray.getMap(i);
+-        ReadableMap additional = map.hasKey("additional") ? map.getMap("additional") : null;
+-        String functionName = map.hasKey("functionName") ? map.getString("functionName") : "Unknown Function";
+-        String className = map.hasKey("className") ? map.getString("className") : "Unknown Class";
+-        StackTraceElement stack = new StackTraceElement(
+-          className,
+-          functionName,
+-          map.getString("fileName"),
+-          map.hasKey("lineNumber") ? map.getInt("lineNumber") : -1
+-        );
+-        stackList.add(stack);
+-
+-        if(additional != null){
+-          StackTraceElement s = new StackTraceElement(
+-            "Additional Parameters",
+-            additional.toString(),
+-            map.getString("fileName"),
+-            map.hasKey("lineNumber") ? map.getInt("lineNumber") : -1
+-          );
+-          stackList.add(s);
+-        }
+-      }
+-      StackTraceElement[] stackTrace =  new StackTraceElement[stackList.size()];
+-      Exception e = new Exception(name + "\n" + reason);
+-      stackTrace = stackList.toArray(stackTrace);
+-      e.setStackTrace(stackTrace);
+-      Crashlytics.logException(e);
+-  }
+-
+-  @ReactMethod
+-  public void setBoolValue(final String key, final boolean boolValue) {
+-    Crashlytics.setBool(key, boolValue);
+-  }
+-
+-  @ReactMethod
+-  public void setFloatValue(final String key, final float floatValue) {
+-    Crashlytics.setFloat(key, floatValue);
+-  }
+-
+-  @ReactMethod
+-  public void setIntValue(final String key, final int intValue) {
+-    Crashlytics.setInt(key, intValue);
+-  }
+-
+-  @ReactMethod
+-  public void setStringValue(final String key, final String stringValue) {
+-    Crashlytics.setString(key, stringValue);
+-  }
+-
+-  @ReactMethod
+-  public void setUserIdentifier(String userId) {
+-    Crashlytics.setUserIdentifier(userId);
+-  }
+-
+-  @ReactMethod
+-  public void setUserName(String userName) {
+-    Crashlytics.setUserName(userName);
+-  }
+-
+-  @ReactMethod
+-  public void setUserEmail(String userEmail) {
+-    Crashlytics.setUserEmail(userEmail);
+-  }
+-
+-  @ReactMethod
+-  public void enableCrashlyticsCollection() {
+-    Fabric.with(getReactApplicationContext(), new Crashlytics());
+-  }
+-
+-}
+diff --git a/node_modules/react-native-firebase/android/src/main/java/io/invertase/firebase/fabric/crashlytics/RNFirebaseCrashlyticsPackage.java b/node_modules/react-native-firebase/android/src/main/java/io/invertase/firebase/fabric/crashlytics/RNFirebaseCrashlyticsPackage.java
+deleted file mode 100644
+index 44f31e3..0000000
+--- a/node_modules/react-native-firebase/android/src/main/java/io/invertase/firebase/fabric/crashlytics/RNFirebaseCrashlyticsPackage.java
++++ /dev/null
+@@ -1,38 +0,0 @@
+-package io.invertase.firebase.fabric.crashlytics;
+-
+-import com.facebook.react.ReactPackage;
+-import com.facebook.react.bridge.NativeModule;
+-import com.facebook.react.bridge.ReactApplicationContext;
+-import com.facebook.react.uimanager.UIManagerModule;
+-import com.facebook.react.uimanager.ViewManager;
+-
+-import java.util.ArrayList;
+-import java.util.Collections;
+-import java.util.List;
+-
+-@SuppressWarnings("unused")
+-public class RNFirebaseCrashlyticsPackage implements ReactPackage {
+-  public RNFirebaseCrashlyticsPackage() {
+-  }
+-
+-  /**
+-   * @param reactContext react application context that can be used to create modules
+-   * @return list of native modules to register with the newly created catalyst instance
+-   */
+-  @Override
+-  public List<NativeModule> createNativeModules(ReactApplicationContext reactContext) {
+-    List<NativeModule> modules = new ArrayList<>();
+-    modules.add(new RNFirebaseCrashlytics(reactContext));
+-
+-    return modules;
+-  }
+-
+-  /**
+-   * @param reactContext
+-   * @return a list of view managers that should be registered with {@link UIManagerModule}
+-   */
+-  @Override
+-  public List<ViewManager> createViewManagers(ReactApplicationContext reactContext) {
+-    return Collections.emptyList();
+-  }
+-}
 diff --git a/node_modules/react-native-firebase/ios/RNFirebase.podspec b/node_modules/react-native-firebase/ios/RNFirebase.podspec
 index 00bafb5..9378698 100644
 --- a/node_modules/react-native-firebase/ios/RNFirebase.podspec
@@ -73,7 +258,7 @@ diff --git a/node_modules/react-native-firebase/ios/RNFirebase/messaging/RNFireb
 index 90fdb1d..92ac092 100644
 --- a/node_modules/react-native-firebase/ios/RNFirebase/messaging/RNFirebaseMessaging.m
 +++ b/node_modules/react-native-firebase/ios/RNFirebase/messaging/RNFirebaseMessaging.m
-@@ -187,8 +187,10 @@ - (void)messaging:(nonnull FIRMessaging *)messaging
+@@ -187,8 +187,10 @@ RCT_EXPORT_METHOD(requestPermission:(RCTPromiseResolveBlock)resolve rejecter:(RC
  }
  
  RCT_EXPORT_METHOD(registerForRemoteNotifications:(RCTPromiseResolveBlock)resolve rejecter:(RCTPromiseRejectBlock)reject) {
@@ -90,7 +275,7 @@ diff --git a/node_modules/react-native-firebase/ios/RNFirebase/notifications/RNF
 index d3aa1e3..b35e7c2 100644
 --- a/node_modules/react-native-firebase/ios/RNFirebase/notifications/RNFirebaseNotifications.m
 +++ b/node_modules/react-native-firebase/ios/RNFirebase/notifications/RNFirebaseNotifications.m
-@@ -102,17 +102,19 @@ - (void)didReceiveLocalNotification:(nonnull UILocalNotification *)localNotifica
+@@ -102,17 +102,19 @@ RCT_EXPORT_MODULE();
  
  RCT_EXPORT_METHOD(complete:(NSString*)handlerKey fetchResult:(UIBackgroundFetchResult)fetchResult) {
      if (handlerKey != nil) {


### PR DESCRIPTION
- Split `pushNotifications` capability into `firebaseIos` and `firebaseAndroid`. This breaks support for CLI-based apps.
- Introduce `crashlytics` capability configuration