### PR TITLE
[MOO-396] Add missing query parameter

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -21,6 +21,13 @@
     <uses-feature android:name="android.hardware.bluetooth_le" android:required="false" />
     <uses-feature android:name="android.hardware.nfc" android:required="false" />
 
+    <queries>
+        <intent>
+            <action android:name="android.intent.action.VIEW" />
+            <data android:scheme="https"/>
+        </intent>
+    </queries>
+
     <application
       android:name=".MainApplication"
       android:label="@string/app_name"


### PR DESCRIPTION
For Android 11+ package visibility was introduced https://developer.android.com/training/package-visibility; this limits the visible app the application gets access to. 

As documented https://reactnative.dev/docs/linking#canopenurl a query tag needs to be added to the AndroidManifest.xml
