### PR TITLE
[MOO-396] Add tel query scheme for Android 11

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -26,6 +26,10 @@
             <action android:name="android.intent.action.VIEW" />
             <data android:scheme="https"/>
         </intent>
+        <intent>
+            <action android:name="android.intent.action.VIEW"/>
+            <data android:scheme="tel"/>
+        </intent>
     </queries>
 
     <application


### PR DESCRIPTION
Android 11 requires the Queries attribute in the Android Manifest to support using external activities. By default Mendix provides actions for call, text and opening websites, hence these parameters are required.