### PR TITLE
[MOO-396] Add queries attribute to Android

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -105,7 +105,7 @@ dependencies {
     implementation fileTree(dir: "libs", include: ["*.jar"])
     implementation "com.facebook.react:react-native:+"  // From node_modules
     implementation "org.webkit:android-jsc:r245459"
-    devImplementation "androidx.constraintlayout:constraintlayout:2.0.0-beta2"
+    devImplementation "androidx.constraintlayout:constraintlayout:2.1.1"
     devImplementation "me.dm7.barcodescanner:zxing:1.9.13"
 
     // Explicit add okhttp

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -21,6 +21,17 @@
     <uses-feature android:name="android.hardware.bluetooth_le" android:required="false" />
     <uses-feature android:name="android.hardware.nfc" android:required="false" />
 
+    <queries>
+        <intent>
+             <action android:name="android.intent.action.VIEW" />
+             <data android:scheme="https"/>
+         </intent>
+         <intent>
+             <action android:name="android.intent.action.VIEW"/>
+             <data android:scheme="tel"/>
+         </intent>
+     </queries>
+
     <application
       android:name=".MainApplication"
       android:label="@string/app_name"

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -19,7 +19,7 @@ buildscript {
         }
     }
     dependencies {
-        classpath "com.android.tools.build:gradle:3.4.2"
+        classpath "com.android.tools.build:gradle:3.4.3"
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlinVersion"
         apply from: file("./mendixnative-release/mendix.gradle"); applyMendixClassPaths(project)
 


### PR DESCRIPTION
Android 11 requires the Queries attribute in the Android Manifest to support using external activities. By default Mendix provides actions for call, text and opening websites, hence these parameters are required.