### PR TITLE
Fix issue opening http URLs in Native Mobile for Android 12

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -32,6 +32,10 @@
             <data android:scheme="https"/>
         </intent>
         <intent>
+            <action android:name="android.intent.action.VIEW" />
+            <data android:scheme="http"/>
+        </intent>
+        <intent>
             <action android:name="android.intent.action.VIEW"/>
             <data android:scheme="tel"/>
         </intent>


### PR DESCRIPTION
Fixed the issue of opening http URLs in Native Mobile apps using NanoflowCommons OpenURL Javascript action.
Fixes mendix/native-template #547