### PR TITLE
feat: drop mendix jcenter

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -18,9 +18,6 @@ buildscript {
         maven {
             url "https://maven.fabric.io/public"
         }
-        maven {
-            url "https://packages.rnd.mendix.com/jcenter"
-        }
     }
     dependencies {
         classpath 'com.android.tools.build:gradle:4.0.2'
@@ -58,12 +55,8 @@ allprojects {
             url "$rootDir/../node_modules/jsc-android/dist"
         }
         maven {
-            url "https://maven.fabric.io/public"
-        }
-        maven {
             url "$rootDir/../node_modules/detox/Detox-android"
         }
-        maven { url "https://packages.rnd.mendix.com/jcenter" }
     }
 
     ext {

--- a/android/gradle.properties
+++ b/android/gradle.properties
@@ -20,4 +20,4 @@ android.useAndroidX=true
 android.enableJetifier=true
 org.gradle.configureondemand=true
 android.disableResourceValidation=true
-FLIPPER_VERSION=0.66.0
+FLIPPER_VERSION=0.99.0

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "@mendix/react-native-sqlite-storage": "5.1.3",
     "react-native-svg": "12.1.0",
     "react-native-vector-icons": "9.2.0",
-    "react-native-video": "^5.2.0"
+    "react-native-video": "^5.2.1"
   },
   "devDependencies": {
     "@babel/runtime": "^7.8.4",


### PR DESCRIPTION
From: "[react-native-video](https://npmjs.com/package/react-native-video)": "[5.2.0](https://npmjs.com/package/react-native-video)"
To: "[react-native-video](https://npmjs.com/package/react-native-video)": "[5.2.1](https://npmjs.com/package/react-native-video)"

allow dropping the Mendix JCenter() + Fabric