### PR TITLE
Improvement: Remove warnings logs "AndroidKeysetManager: keyset not found, will generate a new one"

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -165,7 +165,7 @@ dependencies {
     implementation("com.fasterxml.jackson.core:jackson-core:2.11.3")
     implementation("com.fasterxml.jackson.core:jackson-databind:2.11.3")
     implementation("com.fasterxml.jackson.core:jackson-annotations:2.11.3")
-    implementation 'androidx.security:security-crypto:1.1.0-alpha03'
+    implementation 'androidx.security:security-crypto:1.1.0-alpha04'
 
     // Required for Custom Dev Apps
     devImplementation "androidx.constraintlayout:constraintlayout:2.0.4"


### PR DESCRIPTION
**Impacted version:** 
6.3.4 and older

**Issue:** 

During the execution of the app, we can see tons of warning logs from AndroidKeysetManager that are really noisy and increase a lot the size and readability of the debug logs. If you use a monitoring tool, you can miss some logs because it's truncated because of all those warning messages.

Impact visible on Android **7,8,9,10,11,12**

Current logs:
```
01-12 07:52:15.189 W/AndroidKeysetManager(31534): keyset not found, will generate a new one
01-12 07:52:15.189 W/AndroidKeysetManager(31534): java.io.FileNotFoundException: can't read keyset; the pref value __androidx_security_crypto_encrypted_prefs_key_keyset__ does not exist
01-12 07:52:15.189 W/AndroidKeysetManager(31534): 	at com.google.crypto.tink.integration.android.SharedPrefKeysetReader.readPref(SharedPrefKeysetReader.java:71)
01-12 07:52:15.189 W/AndroidKeysetManager(31534): 	at com.google.crypto.tink.integration.android.SharedPrefKeysetReader.readEncrypted(SharedPrefKeysetReader.java:89)
01-12 07:52:15.189 W/AndroidKeysetManager(31534): 	at com.google.crypto.tink.KeysetHandle.read(KeysetHandle.java:105)
01-12 07:52:15.189 W/AndroidKeysetManager(31534): 	at com.google.crypto.tink.integration.android.AndroidKeysetManager$Builder.read(AndroidKeysetManager.java:311)
01-12 07:52:15.189 W/AndroidKeysetManager(31534): 	at com.google.crypto.tink.integration.android.AndroidKeysetManager$Builder.readOrGenerateNewKeyset(AndroidKeysetManager.java:287)
01-12 07:52:15.189 W/AndroidKeysetManager(31534): 	at com.google.crypto.tink.integration.android.AndroidKeysetManager$Builder.build(AndroidKeysetManager.java:238)
01-12 07:52:15.189 W/AndroidKeysetManager(31534): 	at androidx.security.crypto.EncryptedSharedPreferences.create(EncryptedSharedPreferences.java:155)
01-12 07:52:15.189 W/AndroidKeysetManager(31534): 	at androidx.security.crypto.EncryptedSharedPreferences.create(EncryptedSharedPreferences.java:120)
01-12 07:52:15.189 W/AndroidKeysetManager(31534): 	at com.mendix.mendixnative.encryption.MendixEncryptionToolkitKt.getEncryptedSharedPreferences(MendixEncryptionToolkit.kt:41)
01-12 07:52:15.189 W/AndroidKeysetManager(31534): 	at com.mendix.mendixnative.encryption.MendixEncryptedStorage.<init>(MendixEncryptedStorage.kt:13)
01-12 07:52:15.189 W/AndroidKeysetManager(31534): 	at com.mendix.mendixnative.encryption.MendixEncryptedStorage.<init>(Unknown Source:0)
01-12 07:52:15.189 W/AndroidKeysetManager(31534): 	at com.mendix.mendixnative.encryption.MendixEncryptedStorage$Companion.getMendixEncryptedStorage(MendixEncryptedStorage.kt:42)
01-12 07:52:15.189 W/AndroidKeysetManager(31534): 	at com.mendix.mendixnative.encryption.MendixEncryptedStorageModule.<init>(MendixEncryptedStorageModule.kt:17)
01-12 07:52:15.189 W/AndroidKeysetManager(31534): 	at com.mendix.mendixnative.react.MendixPackage.createNativeModules(MendixPackage.kt:24)
01-12 07:52:15.189 W/AndroidKeysetManager(31534): 	at com.facebook.react.ReactPackageHelper.getNativeModuleIterator(ReactPackageHelper.java:42)
01-12 07:52:15.189 W/AndroidKeysetManager(31534): 	at com.facebook.react.NativeModuleRegistryBuilder.processPackage(NativeModuleRegistryBuilder.java:42)
01-12 07:52:15.189 W/AndroidKeysetManager(31534): 	at com.facebook.react.ReactInstanceManager.processPackage(ReactInstanceManager.java:1347)
01-12 07:52:15.189 W/AndroidKeysetManager(31534): 	at com.facebook.react.ReactInstanceManager.processPackages(ReactInstanceManager.java:1318)
01-12 07:52:15.189 W/AndroidKeysetManager(31534): 	at com.facebook.react.ReactInstanceManager.createReactContext(ReactInstanceManager.java:1240)
01-12 07:52:15.189 W/AndroidKeysetManager(31534): 	at com.facebook.react.ReactInstanceManager.access$1100(ReactInstanceManager.java:131)
01-12 07:52:15.189 W/AndroidKeysetManager(31534): 	at com.facebook.react.ReactInstanceManager$5.run(ReactInstanceManager.java:1023)
01-12 07:52:15.189 W/AndroidKeysetManager(31534): 	at java.lang.Thread.run(Thread.java:919)
01-12 07:52:15.211 I/cr_LibraryLoader(31534): Successfully loaded native library
01-12 07:52:15.212 I/cr_CachingUmaRecorder(31534): Flushed 8 samples from 8 histograms.
01-12 07:52:15.253 I/Zygote  (31728): seccomp disabled by setenforce 0
01-12 07:52:15.255 I/webview_zygote(31728): type=1400 audit(0.0:1014248): avc: denied { read } for name="u:object_r:apexd_prop:s0" dev="tmpfs" ino=27401 scontext=u:r:isolated_app:s0:c104,c291,c512,c768 tcontext=u:object_r:apexd_prop:s0 tclass=file permissive=1
01-12 07:52:15.255 I/webview_zygote(31728): type=1400 audit(0.0:1014249): avc: denied { read } for name="u:object_r:bluetooth_a2dp_offload_prop:s0" dev="tmpfs" ino=27403 scontext=u:r:isolated_app:s0:c104,c291,c512,c768 tcontext=u:object_r:bluetooth_a2dp_offload_prop:s0 tclass=file permissive=1
01-12 07:52:15.265 W/AndroidKeysetManager(31534): keyset not found, will generate a new one
01-12 07:52:15.265 W/AndroidKeysetManager(31534): java.io.FileNotFoundException: can't read keyset; the pref value __androidx_security_crypto_encrypted_prefs_value_keyset__ does not exist
01-12 07:52:15.265 W/AndroidKeysetManager(31534): 	at com.google.crypto.tink.integration.android.SharedPrefKeysetReader.readPref(SharedPrefKeysetReader.java:71)
01-12 07:52:15.265 W/AndroidKeysetManager(31534): 	at com.google.crypto.tink.integration.android.SharedPrefKeysetReader.readEncrypted(SharedPrefKeysetReader.java:89)
01-12 07:52:15.265 W/AndroidKeysetManager(31534): 	at com.google.crypto.tink.KeysetHandle.read(KeysetHandle.java:105)
01-12 07:52:15.265 W/AndroidKeysetManager(31534): 	at com.google.crypto.tink.integration.android.AndroidKeysetManager$Builder.read(AndroidKeysetManager.java:311)
01-12 07:52:15.265 W/AndroidKeysetManager(31534): 	at com.google.crypto.tink.integration.android.AndroidKeysetManager$Builder.readOrGenerateNewKeyset(AndroidKeysetManager.java:287)
01-12 07:52:15.265 W/AndroidKeysetManager(31534): 	at com.google.crypto.tink.integration.android.AndroidKeysetManager$Builder.build(AndroidKeysetManager.java:238)
01-12 07:52:15.265 W/AndroidKeysetManager(31534): 	at androidx.security.crypto.EncryptedSharedPreferences.create(EncryptedSharedPreferences.java:160)
01-12 07:52:15.265 W/AndroidKeysetManager(31534): 	at androidx.security.crypto.EncryptedSharedPreferences.create(EncryptedSharedPreferences.java:120)
01-12 07:52:15.265 W/AndroidKeysetManager(31534): 	at com.mendix.mendixnative.encryption.MendixEncryptionToolkitKt.getEncryptedSharedPreferences(MendixEncryptionToolkit.kt:41)
01-12 07:52:15.265 W/AndroidKeysetManager(31534): 	at com.mendix.mendixnative.encryption.MendixEncryptedStorage.<init>(MendixEncryptedStorage.kt:13)
01-12 07:52:15.265 W/AndroidKeysetManager(31534): 	at com.mendix.mendixnative.encryption.MendixEncryptedStorage.<init>(Unknown Source:0)
01-12 07:52:15.265 W/AndroidKeysetManager(31534): 	at com.mendix.mendixnative.encryption.MendixEncryptedStorage$Companion.getMendixEncryptedStorage(MendixEncryptedStorage.kt:42)
01-12 07:52:15.265 W/AndroidKeysetManager(31534): 	at com.mendix.mendixnative.encryption.MendixEncryptedStorageModule.<init>(MendixEncryptedStorageModule.kt:17)
01-12 07:52:15.265 W/AndroidKeysetManager(31534): 	at com.mendix.mendixnative.react.MendixPackage.createNativeModules(MendixPackage.kt:24)
01-12 07:52:15.265 W/AndroidKeysetManager(31534): 	at com.facebook.react.ReactPackageHelper.getNativeModuleIterator(ReactPackageHelper.java:42)
01-12 07:52:15.265 W/AndroidKeysetManager(31534): 	at com.facebook.react.NativeModuleRegistryBuilder.processPackage(NativeModuleRegistryBuilder.java:42)
01-12 07:52:15.265 W/AndroidKeysetManager(31534): 	at com.facebook.react.ReactInstanceManager.processPackage(ReactInstanceManager.java:1347)
01-12 07:52:15.265 W/AndroidKeysetManager(31534): 	at com.facebook.react.ReactInstanceManager.processPackages(ReactInstanceManager.java:1318)
01-12 07:52:15.265 W/AndroidKeysetManager(31534): 	at com.facebook.react.ReactInstanceManager.createReactContext(ReactInstanceManager.java:1240)
01-12 07:52:15.265 W/AndroidKeysetManager(31534): 	at com.facebook.react.ReactInstanceManager.access$1100(ReactInstanceManager.java:131)
01-12 07:52:15.265 W/AndroidKeysetManager(31534): 	at com.facebook.react.ReactInstanceManager$5.run(ReactInstanceManager.java:1023)
01-12 07:52:15.265 W/AndroidKeysetManager(31534): 	at java.lang.Thread.run(Thread.java:919)
```

With the improvement:
```
01-12 12:17:07.181 I/AndroidKeysetManager(10264): keyset not found, will generate a new one. can't read keyset; the pref value __androidx_security_crypto_encrypted_prefs_key_keyset__ does not exist
01-12 12:17:07.210 I/AndroidKeysetManager(10264): keyset not found, will generate a new one. can't read keyset; the pref value __androidx_security_crypto_encrypted_prefs_value_keyset__ does not exist
```

Reported issue: https://issuetracker.google.com/issues/185219606
Fixed in: https://developer.android.com/jetpack/androidx/releases/security#security-crypto-1.1.0-alpha04