### PR TITLE
Pin androidXAnnotation and androidXBrowser version

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -10,6 +10,8 @@ buildscript {
         excludeAppGlideModule = true
         playServicesVersion = "16.1.0"
         androidXCore = "1.6.0"
+        androidXAnnotation = "1.5.0"
+        androidXBrowser = "1.4.0"
     }
     repositories {
         google()


### PR DESCRIPTION
Fixes compilation errors because latest version was used which broke the build.