### PR TITLE
[MOO-905] Add cached maven repos to repository list

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -73,6 +73,15 @@ allprojects {
         }
         maven { url "https://packages.rnd.mendix.com/jcenter" }
         maven { url "https://www.jitpack.io" }
+        maven {
+            url "https://maven.scijava.org/content/repositories/public/"
+        }
+        maven {
+            url "https://maven.scijava.org/content/repositories/jitpack/"
+        }
+        maven {
+            url "https://maven.scijava.org/content/repositories/jcenter/"
+        }
     }
 
     ext {


### PR DESCRIPTION
Jitpack has been down multiple times now and jcenter has caused issues in the past. We are adding cached fallback repositories for when this happens again.