### PR TITLE
Fix mailto scheme

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -39,6 +39,10 @@
         </intent>
         <intent>
             <action android:name="android.intent.action.VIEW"/>
+            <data android:scheme="mailto"/>
+        </intent>
+        <intent>
+            <action android:name="android.intent.action.VIEW"/>
             <data android:scheme="google.navigation"/>
         </intent>
     </queries>


### PR DESCRIPTION
In the Nanoflow Commons, https://marketplace.mendix.com/link/component/109515, there is an action, “DraftEmail” This works fine in the Make it native app on iOS and Android. When building an app for the customer, the function performs as expected on iOS but fails on Android.

This can be fixed by adding mailto scheme in the manifest

Fixes support ticket #180301