### PR TITLE
[MOO-1017]: Adding Conditional Advertising ID Permission to Android Manifest

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
+- Introduced `com.google.android.gms.permission.AD_ID` permission to the Android Manifest file. This permission governs access to the advertising ID, facilitating more effective targeting and personalization within the app's advertisement services. (Note: This permission is currently disabled with the tools:node="remove" attribute.)
+
+## [7.0.5] - 2023-08-23
+
 ### Fixed
 
 - We upgraded android SDK version to 33

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -23,6 +23,9 @@
     <!-- Required for scheduling local notifications -->
     <uses-permission android:name="android.permission.SCHEDULE_EXACT_ALARM" />
 
+    <!-- If this app uses ads, remove 'tools:node="remove"' to enable ad ID access. -->
+    <uses-permission android:name="com.google.android.gms.permission.AD_ID" tools:node="remove"/>
+
     <!-- Mark the following features as required to filter out devices missing these features. See:
         https://developer.android.com/guide/topics/manifest/uses-feature-element -->
     <uses-feature android:name="android.hardware.camera" android:required="false" />


### PR DESCRIPTION
Added the com.google.android.gms.permission.AD_ID permission to the manifest file. This permission is initially disabled to prevent unnecessary access to the user's advertising ID. If the app integrates ads, the tools:node="remove" attribute will need to be removed to facilitate ad personalization and tracking capabilities.