### PR TITLE
[MOO-1257]: Update androidManfist to fix openUrl action error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ### Fixed
 
 - We fixed build errors caused by the recent XCode 15 update.
+- We have Updated androidManifest to support open url with links to websites whose apps are installed on the device.
 
 ## [7.0.8] - 2023-09-25
 

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -35,7 +35,7 @@
     <queries>
         <intent>
             <action android:name="android.intent.action.VIEW" />
-            <data android:scheme="https"/>
+            <data android:scheme="https" android:host="*"/>
         </intent>
         <intent>
             <action android:name="android.intent.action.VIEW"/>


### PR DESCRIPTION
Updated androidManifest to support open url with links to websites whose apps are installed on the device.