### PR TITLE
Fix/kotlinversion

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -120,7 +120,7 @@ dependencies {
     implementation "com.facebook.react:react-android"
 
     implementation "androidx.core:core-ktx:1.3.2"
-    implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
+    implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlinVersion"
 
     implementation "com.facebook.react:react-native:+"  // From node_modules
 

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -6,7 +6,7 @@ buildscript {
         minSdkVersion = 21
         compileSdkVersion = 33
         targetSdkVersion = 33
-        kotlin_version = "1.7.21"
+        kotlinVersion = "1.7.21"
         excludeAppGlideModule = true
         androidx_lifecycle_version = "2.3.1"
         playServicesVersion = "18+"


### PR DESCRIPTION
`kotlin_version` should be `kotlinVersion` to allow third-party libraries to work without extra effort.

Currently, I'm forced to add one more line:
kotlin_version = "1.8.0"
kotlinVersion = "1.8.0"

You can check on regular RN projects too, it's `kotlinVersion`