### PR TITLE
Fix build issue with JCenter & Jitpack

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -41,12 +41,15 @@ buildscript {
 allprojects {
     repositories {
         all { repo ->
-            println repo.url.toString()
-            if (repo.url.toString().contains("jcenter.bintray.com") || repo.url.toString().contains("jitpack.io")) {
-                project.logger.warn "Repository ${repo.url} removed."
-                remove repo
-                google()
-                mavenCentral()
+            println repo.toString()
+            if (repo instanceof org.gradle.api.artifacts.repositories.MavenArtifactRepository) {
+                println repo.url.toString()
+                if (repo.url.toString().contains("jcenter.bintray.com") /*|| repo.url.toString().contains("jitpack.io")*/) {
+                    project.logger.warn "Repository ${repo.url} removed."
+                    remove repo
+                    google()
+                    mavenCentral()
+                }
             }
         }
         maven {


### PR DESCRIPTION
the current condition impacts too many things, it should be filtered by: `org.gradle.api.artifacts.repositories.MavenArtifactRepository`

More than that, jitpack.io should not be removed, it's breaking few third-party library that needs it (or make it optional)