### PR TITLE
Transitioning from Java 11 to 17

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -99,12 +99,8 @@ android {
             proguardFiles getDefaultProguardFile("proguard-android.txt"), "proguard-rules.pro"
         }
     }
-    compileOptions {
-        sourceCompatibility JavaVersion.VERSION_11
-        targetCompatibility JavaVersion.VERSION_11
-    }
-    kotlinOptions {
-        jvmTarget = JavaVersion.VERSION_11.toString()
+    kotlin {
+        jvmToolchain(17)
     }
     buildFeatures {
         viewBinding true


### PR DESCRIPTION
Switch to the usage of `kotlin {}`
Ensure local builds are **always** using the correct version of JAVA