### PR TITLE
fixed an issue by updating playServicesVersion [9.24]

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -9,7 +9,7 @@ buildscript {
         kotlin_version = "1.7.21"
         excludeAppGlideModule = true
         androidx_lifecycle_version = "2.3.1"
-        playServicesVersion = "18+"
+        playServicesVersion = "18.6.0"
         firebaseMessagingVersion = "21.0.0"
         androidXCore = "1.6.0"
         androidXBrowser = "1.2.0"


### PR DESCRIPTION
Due to the latest update in google play services, some clients have error during apk building process on android.

Here is the update that causes the issue https://developers.google.com/android/guides/releases After the google update we are using 18.7.0 in mendix native which asks for gradle 8.2.0 as we defined it 18+ it gets latest version.

I fixed this by specifying the exact version.