### PR TITLE
fixed an issue by updating playServicesVersion [10.18]

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -141,6 +141,11 @@ dependencies {
 configurations.all {
     resolutionStrategy {
         force "androidx.annotation:annotation:1.1.0"
+        force(
+            "com.google.android.gms:play-services-base:18.6.0",
+            "com.google.android.gms:play-services-basement:18.6.0",
+            "com.google.android.gms:play-services-tasks:18.2.1"
+        )
     }
 }
 

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -8,7 +8,7 @@ buildscript {
         kotlinVersion = "1.9.24"
         excludeAppGlideModule = true
         androidx_lifecycle_version = "2.8.6"
-        playServicesVersion = "18.6.0"
+        playServicesVersion = "18+"
         firebaseMessagingVersion = "21.0.0"
         androidXCore = "1.6.0"
         androidXBrowser = "1.3.0"


### PR DESCRIPTION
Due to the latest update in google play services, some clients have error during apk building process on android.

Here is the update that causes the issue https://developers.google.com/android/guides/releases After the google update a lot of dependencies started using latest version which is not compatible with our gradle version.

Because of that I fixed some versions to the previous one to prevent this issue.