### PR TITLE
Fix apply patch firebase messaging dependency

### DIFF
--- a/patches/apply-patches.js
+++ b/patches/apply-patches.js
@@ -9,7 +9,7 @@ const patchOperations = [
         patchFile: "react-native-geocoder+0.5.0.patch"
     },
     {
-        dependency: "@react-native-firebase/app",
+        dependency: "@react-native-firebase/messaging",
         patchFile: "@react-native-firebase+messaging+17.3.0.patch"
     }
 ];


### PR DESCRIPTION
Fixes support ticket https://support.mendix.com/hc/en-us/requests/241801

1. The apply patch checked if the module dependency: "@react-native-firebase/app" is installed
2. If soo, it applies the tries to apply patchFile: "@react-native-firebase+messaging+17.3.0.patch"
3. It tries to patch the node_modules/@react-native-firebase/messaging
4. Our situation, we use Crashlytics ON, and notifications OFF.
5. Therefore @react-native-firebase/app is installed but @react-native-firebase/messaging is not
6. Resulting in an error when running the patches.

![image](https://github.com/user-attachments/assets/356cca74-0b50-4d56-8eab-75e84b1bcb35)


Checking the correct dependency should fix the problem.
