### PR TITLE
Upgrade mendix/native version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "hasInstallScript": true,
       "dependencies": {
         "@gorhom/bottom-sheet": "^5.1.1",
-        "@mendix/native": "9.0.4",
+        "@mendix/native": "9.0.6",
         "@op-engineering/op-sqlite": "9.2.7",
         "@react-native-async-storage/async-storage": "2.0.0",
         "@react-native-camera-roll/camera-roll": "7.4.0",
@@ -1778,9 +1778,9 @@
       }
     },
     "node_modules/@mendix/native": {
-      "version": "9.0.4",
-      "resolved": "https://registry.npmjs.org/@mendix/native/-/native-9.0.4.tgz",
-      "integrity": "sha512-4WQZiRR1l1Mggpue7EOs2vQL6DyDmmVzcTzaMMrqzIF9GyqocrXjOqYGthlcQpF8k9/rQPgDojntrxGApjPWUA=="
+      "version": "9.0.6",
+      "resolved": "https://registry.npmjs.org/@mendix/native/-/native-9.0.6.tgz",
+      "integrity": "sha512-hK4foaM+1x/Ygqz863+HEl3TOVg2Hs85GWbAoRGDCSANHM/BpSIikSm9xa+lYG/h3x4micTj5SO+9t5b74MwbQ=="
     },
     "node_modules/@mendix/native-mobile-toolkit": {
       "version": "1.0.127",

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   },
   "dependencies": {
     "@gorhom/bottom-sheet": "^5.1.1",
-    "@mendix/native": "9.0.4",
+    "@mendix/native": "9.0.6",
     "@op-engineering/op-sqlite": "9.2.7",
     "@react-native-async-storage/async-storage": "2.0.0",
     "@react-native-camera-roll/camera-roll": "7.4.0",


### PR DESCRIPTION
Upgrade mendix/native version to address native binary version mismatch issue

## Description

Studio Pro 10.24 expects NATIVE_BINARY_VERSION to be 14 for OTA to work correctly. Current @mendix/native(v9.0.4) has NATIVE_BINARY_VERSION=13. Released another version of @mendix/native(v9.0.6) with NATIVE_BINARY_VERSION=14 and integrating same here.

## Checklist

To ensure this pull request meets the requirements for merging, please complete the checklist below:

- [ ] **Release Note:** I have added a release note in the [Mendix Docs repository](https://github.com/mendix/docs) relevant to the changes introduced in this PR.
  - **Link to release note:** [Provide the link here]
- [ ] **Breaking Changes:** This PR introduces breaking changes (e.g., changes that require updates to existing configurations, dependencies).
  - [ ] If yes, I have documented these breaking changes and provided guidance for users to adapt.
  - **Details about breaking changes:** [Provide details here, if applicable]

## This PR contains

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [x] Dependency Upgrade(s) (add versions)
- [ ] Other (describe)

## Important Notes

- PRs **will not be merged** without a corresponding release note update in the Mendix Docs repository.
- Make sure the release note accurately describes the changes and impacts introduced by this PR.
- If documentation update is not required, add a comment with `skip-docs-check` to skip the docs check.

Thank you for keeping our documentation up-to-date! 🚀

## What should be covered while testing?

_..._

## Extra comments (optional)

_Please add extra comments or delete the section if not required_
