### PR TITLE
chore: change macos label from latest to 14 for actions

### DIFF
--- a/.github/workflows/ios-build-custom-dev-app.yml
+++ b/.github/workflows/ios-build-custom-dev-app.yml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   build:
-    runs-on: macos-latest
+    runs-on: macos-14 # macos-latest now points to macos-15, xcode 15.4 required for build is not available on macos-15 - https://github.com/actions/runner-images/issues/12520
 
     steps:
       - uses: actions/checkout@v3


### PR DESCRIPTION
## This PR contains

- [ ] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Dependency Upgrade(s) (add versions)
- [x] Other - Action runner label change from latest to macos-14
