### PR TITLE
[MOO-2195] Version logs events in firebase fix for android

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - We updated `.gitignore` to more precisely exclude `node_modules` directories in specific locations.
 - We added a new dependency for `@shopify/flash-list` to support the migration from FlatList to FlashList.
 - Fix the iOS builds crashing when building with Xcode 26.
+- We resolved an issue that version logs events are not getting recorded in firebase for Android.
 
 ## [17.0.4] - 2026-01-22
 

--- a/capabilities-setup-config.json
+++ b/capabilities-setup-config.json
@@ -47,7 +47,10 @@
                 "plugins": [
                     "com.google.gms.google-services"
                 ]
-            }
+            },
+            "externalDependencies": [
+                "com.google.firebase:firebase-analytics"
+            ]
         }
     },
     "firebaseIos": {


### PR DESCRIPTION
## Description

This PR fixes the issue of not logging version events like user_engagement, screen_view etc in firebase for android .

## Checklist

To ensure this pull request meets the requirements for merging, please complete the checklist below:

- [x] **Release Note:** As a part of the release process, an automated PR will be created for the [Mendix Docs repository](https://github.com/mendix/docs) relevant to the changes introduced in this PR. Post release, please ensure that the release note accurately reflects the changes and impacts of this PR.
- [ ] **Breaking Changes:** This PR introduces breaking changes (e.g., changes that require updates to existing configurations, dependencies).
  - [ ] If yes, I have documented these breaking changes and provided guidance for users to adapt.
  - **Details about breaking changes:** [Provide details here, if applicable]

## This PR contains

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Other (describe)

## Important Notes

- Make sure the release note accurately describes the changes and impacts introduced by this PR.

Thank you for keeping our documentation up-to-date! 🚀
