### PR TITLE
[MOO-1915] - Remove fallback maven repos

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -74,15 +74,6 @@ allprojects {
             url "https://maven.fabric.io/public"
         }
         maven { url "https://www.jitpack.io" }
-        maven {
-            url "https://maven.scijava.org/content/repositories/public/"
-        }
-        maven {
-            url "https://maven.scijava.org/content/repositories/jitpack/"
-        }
-        maven {
-            url "https://maven.scijava.org/content/repositories/jcenter/"
-        }
         maven { url "https://packages.rnd.mendix.com/jcenter" }
     }
 


### PR DESCRIPTION
## Description

In this PR removed fallback maven repos. Its already removed in master and release/17.x.x branches. This are added 3 years back as Jitpack and jcenter are often down or causing the issues at that time. 

## Checklist

To ensure this pull request meets the requirements for merging, please complete the checklist below:

- [x] **Release Note:** As a part of the release process, an automated PR will be created for the [Mendix Docs repository](https://github.com/mendix/docs) relevant to the changes introduced in this PR. Post release, please ensure that the release note accurately reflects the changes and impacts of this PR.
- [ ] **Breaking Changes:** This PR introduces breaking changes (e.g., changes that require updates to existing configurations, dependencies).
  - [ ] If yes, I have documented these breaking changes and provided guidance for users to adapt.
  - **Details about breaking changes:** [Provide details here, if applicable]

## This PR contains

- [ ] Bug fix
- [ ] Feature
- [x] Refactor
- [ ] Documentation
- [ ] Other (describe)

## Important Notes

- Make sure the release note accurately describes the changes and impacts introduced by this PR.
