### PR TITLE
[MOO-2419] Force hermes v0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
+- We addressed a random scenario where gradle would resolve to using the Hermes v1 compiler instead of the old hermes override in gradle.properties. This would throw issues with "...bytecode mismatch...".
+
 ## [19.1.4] - 2026-08-24
 
 - We hardened the Android main screen against overlay and tapjacking attacks, and removed the unused `SYSTEM_ALERT_WINDOW` permission.

--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -144,6 +144,9 @@ dependencies {
 
 configurations.all {
     resolutionStrategy {
+        // Force Hermes V0 version across all configurations to prevent random resolution due to gradle caching/timing issues.
+        force "com.facebook.hermes:hermes-android:0.15.1"
+        
         force "androidx.annotation:annotation:1.1.0"
         force(
             "com.google.android.gms:play-services-base:18.6.0",


### PR DESCRIPTION
## Description

This PR addresses a scenario where gradle would resolve to using the new hermes v1 instead of the overriden hermes v0 in gradle.properties.

## Checklist

To ensure this pull request meets the requirements for merging, please complete the checklist below:

- [ ] **Release Note:** As a part of the release process, an automated PR will be created for the [Mendix Docs repository](https://github.com/mendix/docs) relevant to the changes introduced in this PR. Post release, please ensure that the release note accurately reflects the changes and impacts of this PR.

## This PR contains

- [X] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Other (describe)

## Important Notes

- Make sure the release note accurately describes the changes and impacts introduced by this PR.


## What should be covered while testing?

Building the Android app using the devDebug variant _(since it will perform js bundling task)_.
